### PR TITLE
CORDA-1067 - Fix Scheduled State

### DIFF
--- a/src/main/kotlin/com/heartbeat/HeartState.kt
+++ b/src/main/kotlin/com/heartbeat/HeartState.kt
@@ -11,19 +11,23 @@ import java.time.Instant
  * Every Heartbeat state has a scheduled activity to start a flow to consume itself and produce a
  * new Heartbeat state on the ledger after five seconds.
  *
- * @param me The creator of the Heartbeat state.
+ * @property me The creator of the Heartbeat state.
  * @property nextActivityTime When the scheduled activity should be kicked off.
  */
-class HeartState(private val me: Party) : SchedulableState {
+class HeartState(
+        private val me: Party,
+        private val nextActivityTime: Instant = Instant.now().plusSeconds(1)
+) : SchedulableState {
+
     override val participants get() = listOf(me)
-    // A heartbeat will be emitted every second.
-    // We get the time when the scheduled activity will occur here rather than in nextScheduledActivity. This is
-    // because calling Instant.now() in nextScheduledActivity returns the time at which the function is called, rather
-    // than the time at which the state was created.
-    private val nextActivityTime = Instant.now().plusSeconds(1)
 
     // Defines the scheduled activity to be conducted by the SchedulableState.
     override fun nextScheduledActivity(thisStateRef: StateRef, flowLogicRefFactory: FlowLogicRefFactory): ScheduledActivity? {
+        // A heartbeat will be emitted every second.
+        // We get the time when the scheduled activity will occur in the constructor rather than in this method. This is
+        // because calling Instant.now() in nextScheduledActivity returns the time at which the function is called, rather
+        // than the time at which the state was created.
         return ScheduledActivity(flowLogicRefFactory.create(HeartbeatFlow::class.java, thisStateRef), nextActivityTime)
     }
+
 }


### PR DESCRIPTION
With the shift from Kryo to AMQP we depend on having all serialised data settable from the constructor. Consequently, this commit removes the field initialiser and uses a default value on an alternative constructor for `HeartState` instead.